### PR TITLE
Update NodeJS to v16

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,12 +17,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Npm install

--- a/action.yml
+++ b/action.yml
@@ -39,5 +39,5 @@ inputs:
     description: "Set this to true if you want to use a mlcommons cla bot"
     default: true
 runs:
-  using: "node12"
+  using: "node16"
   main: "lib/main.js"


### PR DESCRIPTION
See GitHub [announcement](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/) and [documentation](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/).

CLA success tested [here](https://github.com/mlcommons/cla-bot-test/actions/runs/5765649761).

CLA fail tested [here](https://github.com/mlcommons/cla-bot-test/actions/runs/5790231045).